### PR TITLE
fix: run the chair position checks for /sit

### DIFF
--- a/modules/betterchairs-plugin/src/main/java/de/sprax2013/betterchairs/BetterChairsCommand.java
+++ b/modules/betterchairs-plugin/src/main/java/de/sprax2013/betterchairs/BetterChairsCommand.java
@@ -82,11 +82,22 @@ public class BetterChairsCommand implements CommandExecutor, TabCompleter {
                 b = p.getLocation().getBlock().getRelative(BlockFace.DOWN);
             }
 
-            if (b != null) {
-                getManager().create(p, b);
-            } else {
+            if (b == null) {
                 sender.sendMessage(Messages.getPrefix() + " §cYou need to be on solid ground");
+                return true;
             }
+
+            if (Settings.CHAIR_NEED_AIR_ABOVE.getValueAsBoolean() && !b.getRelative(BlockFace.UP).isEmpty()) {
+                sender.sendMessage(Messages.getPrefix() + " §cThere is not enough space above you to sit here");
+                return true;
+            }
+
+            if (!Settings.CHAIR_ALLOW_AIR_BELOW.getValueAsBoolean() && b.getRelative(BlockFace.DOWN).isEmpty()) {
+                sender.sendMessage(Messages.getPrefix() + " §cYou can not sit on a block with air below it");
+                return true;
+            }
+
+            getManager().create(p, b);
         } else if (args.length >= 1) {
             if (args[0].equalsIgnoreCase("toggle")) {
                 handleToggleChairs(sender);


### PR DESCRIPTION
## Problem

`/sit` seats a player on the block they are standing on and never runs the position checks that right-clicking a chair runs. Issue #307: standing on a lantern that hangs from chains and running `/sit` ends with the player's body inside the chain, because the check for air above the seat block does not run on this path.

## Fix

The `/sit` branch of `BetterChairsCommand` now runs those two checks before it creates the chair:

- the seat block needs air above it while `Chairs.Position.NeedAirAbove` is enabled
- the seat block must not have air below it while `Chairs.Position.AllowAirBelow` is disabled

Both values are read on every command, so `/BetterChairs reload` applies them right away. With the defaults (`NeedAirAbove: true`, `AllowAirBelow: true`) only the first one can refuse a player.

I did not apply the chair type checks (`UseStairs`, `UseSlabs`, `Filter.Blocks`, `NeedsSignsOnBothSides`) to `/sit`. The command exists so a player can sit on the ground, and ground blocks are rarely stairs or slabs, so those checks would reject most of its uses.

## Testing

Paper 1.21.11 build 132, offline mode, flat world, a scripted client standing at fixed coordinates, plugin built from this branch. The before column is the v1.20.0 release jar.

| `/sit` on | before | after |
| --- | --- | --- |
| plain ground | sits | sits |
| hanging lantern, chains above | sits, body inside the chain block | refused: "There is not enough space above you to sit here" |
| hanging lantern, `NeedAirAbove: false` | sits | sits |
| stone block with air below, `AllowAirBelow: true` | sits | sits |
| stone block with air below, `AllowAirBelow: false` | sits | refused: "You can not sit on a block with air below it" |

The config changes were made in `config.yml` and applied with `/BetterChairs reload` while the server was running.

Build: `mvn -B clean package` cannot run outside CI here, because it needs locally compiled Spigot artifacts for every supported Minecraft version and CI creates those with SpraxDev/Action-SpigotMC. `mvn -pl modules/betterchairs-api install` and `mvn -pl modules/betterchairs-plugin package` both pass on this diff, and the jar runs on 1.21.11 with the NMS implementation loaded rather than the fallback. The project has no test sources, so there is nothing for `mvn package` to run.

Not tested: any Minecraft version other than 1.21.11, and the seat position itself, since I have no client to look at the screen.

## Notes

- The interact listener refuses silently in the same situation. A command that answers nothing looks broken, so the new refusals send a message, in the same inline style as the existing "You need to be on solid ground" line. Moving all of these into `messages.yml` would be its own change.
- The two position checks now exist in both `EventListener` and `BetterChairsCommand`. Your TODO in `EventListener#onBlockPhysicsMonitor` mentions a central method for checking whether a block may be sat on; I am happy to move them there in a follow-up if you want it.
- `/sit` also skips the player checks the interact listener runs (`BetterChairs.use`, `hasChairsDisabled`, the world filter, `NeedEmptyHands`). I left those out because players who toggled chairs off may still expect `/sit` to work. Say the word and I will add them.
